### PR TITLE
fix: Correct pyproject.toml for setuptools build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,9 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.8"
-license = {text = "MIT License"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Image Recognition",
@@ -32,6 +31,7 @@ dependencies = [
     "scikit-learn" # Added for potential utility, though not explicitly in original scripts, it's very common. If not needed, can be removed.
     # IPython is usually a dependency of jupyterlab, but explicit can be added if needed.
 ]
+py_modules = []
 
 [project.urls]
 "Homepage" = "https://github.com/example/repository" # Placeholder


### PR DESCRIPTION
Addresses issues you encountered when using `uv sync` or `pip install .` with the `pyproject.toml` file.

Changes:
- Modifies the `[project.license]` field in `pyproject.toml` to use the SPDX string identifier "MIT" instead of a table, resolving deprecation warnings.
- Removes the "License :: OSI Approved :: MIT License" classifier as it's redundant with the SPDX identifier.
- Adds `py_modules = []` to the `[project]` table in `pyproject.toml`. This explicitly tells setuptools not to auto-discover top-level packages, resolving the "Multiple top-level packages discovered" error for this notebook-centric project structure.

The README.md instructions for `pip install .` remain appropriate for installing dependencies.